### PR TITLE
R3 Smoke Test Scripts

### DIFF
--- a/r3_smoketest/diff_dswx_files.py
+++ b/r3_smoketest/diff_dswx_files.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+
+"""
+==================
+diff_dswx_files.py
+==================
+
+Python program to perform Quality Assurance Test on a directory of NetCDF4 files.
+This script searches for files with a .tif file extension and calls a subprocess
+script, dswx_comparison.py, which ensures there are matching files in each input
+directory.
+
+"""
+
+import argparse
+import glob
+import os
+import sys
+
+
+def _parse_args():
+    """
+    This function gets the two directory names that are arguments to the module.
+    If no arguments are given, it prints a help message and exits,
+    if only one argument is given, it gives a warning message and aborts.
+
+    Returns
+    --------
+    result : <-1 if FAIL>
+             <0 if HELP>
+             <list - string if PASS>
+        Returns a list of 2 directory names to the calling function.
+
+    """
+    parser = argparse.ArgumentParser(
+        description='Compares sets DSWx-S1 products with the dswx_comparison.py script'
+    )
+    parser.add_argument('input dirs',
+                        type=str,
+                        nargs=2,
+                        help='Expected_dir Output_dir')
+
+    if len(sys.argv) == 1:
+        parser.print_help()
+        sys.exit(0)
+    else:
+        if len(sys.argv) == 2:
+            print("Missing Output_dir")
+            sys.exit(-1)
+
+    return sys.argv
+
+
+def get_files(options):
+    """
+    This function determines the number of files in each directory and, if equal,
+    compares them file by file.
+
+    Notes
+    ------
+    Calls external python script, dswx_comparison.py, to perform the file comparison.
+
+    Parameters
+    ------------
+    options : <list - string>
+       Directory names of expected_dir and output
+
+    Returns
+    --------
+    result : <-1 if FAIL>
+         FAILS if number of files in 2 directories are 0, or unequal.
+
+    """
+    expected_dir = options[1]
+    output_dir = options[2]
+
+    # list to store files
+    exp = [os.path.basename(f) for f in sorted(glob.glob(os.path.join(expected_dir, '*.tif')))]
+    expected_file_count = len(exp)
+
+    expected_count = 0
+    for x in exp:
+        exp[expected_count] = x
+        expected_count += 1
+
+    # list to store files
+    out = [os.path.basename(f) for f in sorted(glob.glob(os.path.join(output_dir, '*.tif')))]
+    output_file_count = len(out)
+
+    output_count = 0
+    for x in out:
+        out[output_count] = x
+        output_count += 1
+
+    if expected_file_count == 0:
+        print("[FAIL]  expected file_count == 0")
+        print("    Expected file count of 0 usually implies a typo in directory name")
+        sys.exit(-1)
+
+    if output_file_count == 0:
+        print("[FAIL]  output file_count == 0")
+        print("    Output file count of 0 usually implies a typo in directory name")
+        sys.exit(-1)
+
+    if output_file_count > expected_file_count:
+        print("[FAIL]  output_file_count ", output_file_count, " exceeds expected_file_count ", expected_file_count)
+        sys.exit(-1)
+
+    if expected_file_count > output_file_count:
+        print("[FAIL]  expected_file_count ", expected_file_count, " exceeds output_file_count ", output_file_count)
+        sys.exit(-1)
+
+    # could also be output_count
+    for i in range(0, expected_count):
+        expected_path = os.path.join(expected_dir, exp[i])
+        output_path = os.path.join(output_dir, out[i])
+        cmd1 = "python3"
+        cmd2 = "dswx_comparison.py"
+        command = cmd1 + ' ' + cmd2 + ' ' + expected_path + ' ' + output_path
+        os.system(command)
+
+
+def main():
+    options = _parse_args()
+    get_files(options)
+
+
+if __name__ == '__main__':
+    main()

--- a/r3_smoketest/dswx_comparison.py
+++ b/r3_smoketest/dswx_comparison.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+#
+
+import argparse
+import os
+import sys
+import numpy as np
+from osgeo import gdal
+
+COMPARE_DSWX_SAR_PRODUCTS_ERROR_TOLERANCE = 1e-6
+COMPARISON_EXCEPTION_LIST = ['PROCESSING_DATETIME',
+                             'INPUT_DEM_SOURCE',
+                             'INPUT_WORLDCOVER_SOURCE',
+                             'INPUT_REFERENCE_WATER_SOURCE',
+                             'INPUT_HAND_SOURCE',
+                             'INPUT_SHORELINE_SOURCE',
+                             'SOFTWARE_VERSION']
+
+
+def _get_parser():
+    parser = argparse.ArgumentParser(
+        description='Compare two DSWx-SAR products',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+
+    # Inputs
+    parser.add_argument('input_file',
+                        type=str,
+                        nargs=2,
+                        help='Input images')
+
+    return parser
+
+
+def _get_prefix_str(flag_same, flag_all_ok):
+    flag_all_ok[0] = flag_all_ok[0] and flag_same
+
+    if flag_same:
+        return '[OK]'
+    else:
+        return '[FAIL]'
+
+
+def _print_first_value_diff(image_1, image_2, prefix):
+    """
+    Print first value difference between two images.
+
+       Parameters
+       ----------
+       image_1 : numpy.ndarray
+            First input image
+       image_2: numpy.ndarray
+            Second input image
+       prefix: str
+            Prefix to the message printed to the user
+    """
+    flag_error_found = False
+    for i in range(image_1.shape[0]):
+        for j in range(image_1.shape[1]):
+            if (abs(image_1[i, j] - image_2[i, j]) >=
+                    COMPARE_DSWX_SAR_PRODUCTS_ERROR_TOLERANCE):
+                flag_error_found = True
+
+                print(prefix + f'     * input 1 has value'
+                      f' "{image_1[i, j]}" in position'
+                      f' (x: {j}, y: {i})'
+                      f' whereas input 2 has value "{image_2[i, j]}"'
+                      ' in the same position.')
+                break
+        if flag_error_found:
+            break
+
+
+def _compare_dswx_sar_metadata(metadata_1, metadata_2):
+    """
+    Compare DSWx-SAR products' metadata
+
+       Parameters
+       ----------
+       metadata_1 : dict
+            Metadata of the first DSWx-SAR product
+       metadata_2: dict
+            Metadata of the second
+    """
+    metadata_error_message = None
+    flag_same_metadata = len(metadata_1.keys()) == len(metadata_2.keys())
+    if not flag_same_metadata:
+        metadata_error_message = (
+            f'* input 1 metadata has {len(metadata_1.keys())} entries'
+            f' whereas input 2 metadata has {len(metadata_2.keys())} entries.')
+
+        set_1_m_2 = set(metadata_1.keys()) - set(metadata_2.keys())
+        if len(set_1_m_2) > 0:
+            metadata_error_message += (' Input 1 metadata has extra entries'
+                                       ' with keys:'
+                                       f' {", ".join(set_1_m_2)}.')
+        set_2_m_1 = set(metadata_2.keys()) - set(metadata_1.keys())
+        if len(set_2_m_1) > 0:
+            metadata_error_message += (' Input 2 metadata has extra entries'
+                                       ' with keys:'
+                                       f' {", ".join(set_2_m_1)}.')
+        return metadata_error_message, flag_same_metadata
+
+    for k1, v1, in metadata_1.items():
+        if k1 in COMPARISON_EXCEPTION_LIST:
+            continue
+
+        if k1 not in metadata_2.keys():
+            flag_same_metadata = False
+            metadata_error_message = (
+                f'* the metadata key {k1} is present in'
+                ' but it is not present in input 2')
+            break
+
+        if k1 == 'RTC_INPUT_LIST':
+            l1 = list(v1)
+            l2 = list(metadata_2[k1])
+
+            if sorted(l1) != sorted(l2):
+                flag_same_metadata = False
+                metadata_error_message = (
+                    f'* RTC_INPUT_LIST differs between inputs, '
+                    f'input 1 has value {l1} whereas input 2 has value {l2}'
+                )
+                break
+
+        elif metadata_2[k1] != v1:
+            flag_same_metadata = False
+            metadata_error_message = (
+                f'* contents of metadata key {k1} from'
+                f' input 1 has value "{v1}" whereas the same key in'
+                f' input 2 metadata has value "{metadata_2[k1]}"')
+            break
+
+    return metadata_error_message, flag_same_metadata
+
+
+def compare_dswx_sar_products(file_1, file_2):
+
+    if not os.path.isfile(file_1):
+        print(f'ERROR file not found: {file_1}')
+        return False
+
+    if not os.path.isfile(file_2):
+        print(f'ERROR file not found: {file_2}')
+        return False
+
+    print('Comparing files:')
+    print(f'    file 1: {file_1}')
+    print(f'    file 2: {file_2}')
+
+    flag_all_ok = [True]
+
+    layer_gdal_dataset_1 = gdal.Open(file_1, gdal.GA_ReadOnly)
+    geotransform_1 = layer_gdal_dataset_1.GetGeoTransform()
+    projection_1 = layer_gdal_dataset_1.GetProjection()
+    metadata_1 = layer_gdal_dataset_1.GetMetadata()
+    nbands_1 = layer_gdal_dataset_1.RasterCount
+
+    layer_gdal_dataset_2 = gdal.Open(file_2, gdal.GA_ReadOnly)
+    geotransform_2 = layer_gdal_dataset_2.GetGeoTransform()
+    projection_2 = layer_gdal_dataset_2.GetProjection()
+    metadata_2 = layer_gdal_dataset_2.GetMetadata()
+    nbands_2 = layer_gdal_dataset_2.RasterCount
+
+    # compare number of bands
+    flag_same_nbands =  nbands_1 == nbands_2
+    flag_same_nbands_str = _get_prefix_str(flag_same_nbands, flag_all_ok)
+    prefix = ' ' * 7
+    print(f'{flag_same_nbands_str}Comparing number of bands')
+    if not flag_same_nbands:
+        print(prefix + f'Input 1 has {nbands_1} bands and input 2'
+              f' has {nbands_2} bands')
+        return False
+
+    # compare array values
+    print('Comparing DSWx bands...')
+    for b in range(1, nbands_1 + 1):
+        gdal_band_1 = layer_gdal_dataset_1.GetRasterBand(b)
+        gdal_band_2 = layer_gdal_dataset_2.GetRasterBand(b)
+        image_1 = gdal_band_1.ReadAsArray(buf_type=gdal.GDT_Int64)
+        image_2 = gdal_band_2.ReadAsArray(buf_type=gdal.GDT_Int64)
+        flag_bands_are_equal = np.allclose(
+            image_1, image_2, atol = COMPARE_DSWX_SAR_PRODUCTS_ERROR_TOLERANCE,
+            equal_nan=True)
+        flag_bands_are_equal_str = _get_prefix_str(flag_bands_are_equal,
+                                                   flag_all_ok)
+        print(f'{flag_bands_are_equal_str}     Band {b} -'
+              f' {gdal_band_1.GetDescription()}"')
+        if not flag_bands_are_equal:
+            _print_first_value_diff(image_1, image_2, prefix)
+
+    # compare geotransforms
+    flag_same_geotransforms = np.array_equal(geotransform_1, geotransform_2)
+    flag_same_geotransforms_str = _get_prefix_str(flag_same_geotransforms,
+                                                  flag_all_ok)
+    print(f'{flag_same_geotransforms_str}Comparing geotransform')
+    if not flag_same_geotransforms:
+        print(prefix + f'* input 1 geotransform with content "{geotransform_1}"'
+              f' differs from input 2 geotransform with content'
+              f' "{geotransform_2}".')
+
+    # compare projections
+    flag_same_projections = np.array_equal(projection_1, projection_2)
+    flag_same_projections_str = _get_prefix_str(flag_same_projections,
+                                                flag_all_ok)
+    print(f'{flag_same_projections_str}Comparing projection')
+    if not flag_same_projections:
+        print(prefix + f'* input 1 projection with content "{projection_1}"'
+              f' differs from input 2 projection with content'
+              f' "{projection_2}".')
+
+    # compare metadata
+    metadata_error_message, flag_same_metadata = \
+        _compare_dswx_sar_metadata(metadata_1, metadata_2)
+
+    flag_same_metadata_str = _get_prefix_str(flag_same_metadata,
+                                             flag_all_ok)
+    print(f'{flag_same_metadata_str}Comparing metadata')
+
+    if not flag_same_metadata:
+        print(prefix + metadata_error_message)
+
+    return flag_all_ok[0]
+
+
+def main():
+    parser = _get_parser()
+
+    args = parser.parse_args()
+
+    file_1 = args.input_file[0]
+    file_2 = args.input_file[1]
+
+    compare_dswx_sar_products(file_1, file_2)
+
+
+if __name__ == '__main__':
+    main()

--- a/r3_smoketest/run_r3_smoketest_validation.sh
+++ b/r3_smoketest/run_r3_smoketest_validation.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# Arguments: DSWx-S1 version, DISP-S1 version, S3 R3 location, release
+# for example: final_0.5.2 final_1.0.1 opera-int-rs-fwd 2.0.0
+
+set -e
+umask 002
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+dswx_s1_v=$1
+disp_s1_v=$2
+s3_rs=$3
+release=$4
+
+# Submit query job
+python3 ~/mozart/ops/opera-pcm/data_subscriber/daac_data_subscriber.py query -c OPERA_L2_RTC-S1_V1 --endpoint=OPS --release-version=${release} --job-queue=opera-job_worker-rtc_data_download --chunk-size=1 --transfer-protocol=auto --native-id=OPERA_L2_RTC-S1_T114-243001-IW3_20231213T121156Z_20231213T190239Z_S1A_30_v1.0*
+# TODO submit DISP-S1 job
+
+# Download and unzip gold files.
+wget https://artifactory-fn.jpl.nasa.gov:443/artifactory/general-stage/gov/nasa/jpl/opera/sds/pcm/testdata_R3.0.0/deployment_smoke_test_dswx_s1_${dswx_s1_v}.zip
+unzip deployment_smoke_test_dswx_s1_${dswx_s1_v}.zip
+# TODO Download and unzip expected DISP-S1 products
+
+echo "Sleeping 60 min initially for the SCIFLO PGE jobs to complete..."
+sleep 3600
+
+# Download output files
+mkdir output_dir_dswx output_dir_disp
+
+# Poll for 17 DSWx-S1 products. DSWx-S1 PGE runs faster than DISP-S1 so we poll and copy these first.
+while [ 17 -ne `aws s3 ls s3://${s3_rs}/products/DSWx_S1/ | grep "OPERA_L3_DSWx-S1_T4.*$" | wc -l` ]
+do
+  echo "Sleeping 5 mins waiting for DSWx products..."
+  sleep 300
+done
+echo "Sleeping 2 mins to make sure all files have transferred to S3"
+sleep 120
+
+echo "Copying down DSWx-S1 products from S3"
+cd output_dir_dswx
+aws s3 cp s3://${s3_rs}/products/DSWx_S1/ $(pwd) --recursive --exclude "*" --include "OPERA_L3_DSWx-S1_T4*"
+
+# TODO Poll and download DISP-S1 products
+
+cd ..
+
+# Run comparisons
+echo "Comparing DSWx-S1 products against gold files"
+expected=($(find ./deployment_smoke_test_dswx_s1_${dswx_s1_v} -maxdepth 1 -mindepth 1 -type d -printf "%f\n"))
+output=($(find ./output_dir_dswx -maxdepth 1 -mindepth 1 -type d -printf "%f\n"))
+
+# Point GDAL to the proj.db file it wants to load, this path assumes the script is being run on mozart
+export PROJ_LIB=/export/home/hysdsops/conda/share/proj
+
+for (( i=0; i<${#expected[@]}; i++ )); do
+  python3 ${SCRIPT_DIR}/diff_dswx_files.py ./deployment_smoke_test_dswx_s1_${dswx_s1_v}/${expected[$i]} ./output_dir_dswx/${output[$i]} 2>&1 | tee -a ./deployment_smoke_test_dswx_s1_${dswx_s1_v}.log
+done
+
+# TODO compare output and expected DISP-S1 products


### PR DESCRIPTION
## Purpose
- This branch adds an orchestration script for conducting a smoke test for R3 PGE's. This includes job kickoff (from mozart), download and deployment of expected products, and comparison of output products to expected.
- The main script currently only supports the smoke test for DSWx-S1 since we cannot generate expected products for DISP-S1 yet
- There is also a known issue where the output and expected products currently fail the comparison state when evaluating the image bands. This may be related to the known issue where the DSWx-S1 SAS produces slightly different values depending on the underlying hardware (Intel vs AMD)
## Testing
- The scripts were tested by cloning the opera-sds-int repo onto an existing mozart instance (configured with v3.0.0-rc.2.0 of the DSWx-S1 PGE) and executing the `run_r3_smoketest_validation.sh` script like so: `./run_r3_smoketest_validation.sh calval_0.4 none opera-dev-rs-fwd-collinss 2.2.0`
